### PR TITLE
fix(cli): do not default code --since to current time

### DIFF
--- a/src/cli/commands/code.ts
+++ b/src/cli/commands/code.ts
@@ -28,7 +28,9 @@ export async function codeCommand(args: string[]) {
   }
 
   const timeout = opts.timeout ? parseInt(opts.timeout) : 30
-  const since = opts.since ?? new Date().toISOString()
+  // No default for since: when omitted, existing codes are matched too,
+  // so a code that arrived just before the command was run is still found.
+  const since = opts.since
 
   console.error(`Waiting for verification code to ${mailbox} (timeout: ${timeout}s)...`)
 

--- a/src/providers/send/hosted.ts
+++ b/src/providers/send/hosted.ts
@@ -55,7 +55,11 @@ export function createHostedSendProvider(apiKey: string, apiUrl?: string): SendP
         process.stderr.write(`  [${data.sends_this_month}/${data.monthly_limit} this month]\n`)
       }
 
-      return { id: data.id!, provider: 'mails.dev' }
+      if (!data.id) {
+        throw new Error('Send succeeded but the API response did not include a message id')
+      }
+
+      return { id: data.id, provider: 'mails.dev' }
     },
   }
 }

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -602,3 +602,86 @@ describe('CLI: inbox command', () => {
     rmSync(saveDir, { recursive: true, force: true })
   })
 })
+
+describe('CLI: code command', () => {
+  const originalLog = console.log
+  const originalError = console.error
+  const originalExit = process.exit
+
+  beforeEach(() => {
+    saveConfig({
+      mode: 'hosted',
+      domain: 'mails.dev',
+      mailbox: 'agent@test.com',
+      send_provider: 'resend',
+      storage_provider: 'sqlite',
+    })
+  })
+
+  afterEach(() => {
+    console.log = originalLog
+    console.error = originalError
+    process.exit = originalExit
+    _resetStorage()
+    mock.restore()
+  })
+
+  function useCodeStorage(getCode: StorageProvider['getCode']) {
+    const provider = {
+      name: 'test',
+      init: mock(async () => {}),
+      saveEmail: mock(async () => {}),
+      getEmails: mock(async () => []),
+      searchEmails: mock(async () => []),
+      getEmail: mock(async () => null),
+      getAttachment: mock(async () => null),
+      getCode,
+    } as StorageProvider
+    _resetStorage(provider)
+    return provider
+  }
+
+  test('does not default --since to now, so pre-existing codes are found', async () => {
+    const getCodeSpy = mock(async () => ({
+      code: '424242',
+      from: 'noreply@service.com',
+      subject: 'Your verification code',
+    }))
+    useCodeStorage(getCodeSpy)
+
+    const output: string[] = []
+    console.log = (msg?: unknown) => { output.push(String(msg ?? '')) }
+    console.error = () => {}
+    process.exit = ((code?: number) => { throw new Error(`exit:${code ?? 0}`) }) as typeof process.exit
+
+    const { codeCommand } = await import('../../src/cli/commands/code')
+    await codeCommand(['--to', 'agent@test.com'])
+
+    expect(getCodeSpy.mock.calls).toHaveLength(1)
+    expect(getCodeSpy.mock.calls[0]).toEqual([
+      'agent@test.com',
+      { timeout: 30, since: undefined },
+    ])
+    expect(output.join('\n')).toContain('424242')
+  })
+
+  test('passes explicit --since through to storage', async () => {
+    const getCodeSpy = mock(async () => null)
+    useCodeStorage(getCodeSpy)
+
+    console.log = () => {}
+    console.error = () => {}
+    process.exit = ((code?: number) => { throw new Error(`exit:${code ?? 0}`) }) as typeof process.exit
+
+    const { codeCommand } = await import('../../src/cli/commands/code')
+    await expect(
+      codeCommand(['--to', 'agent@test.com', '--since', '2025-06-01T00:00:00Z', '--timeout', '5'])
+    ).rejects.toThrow('exit:1')
+
+    expect(getCodeSpy.mock.calls).toHaveLength(1)
+    expect(getCodeSpy.mock.calls[0]).toEqual([
+      'agent@test.com',
+      { timeout: 5, since: '2025-06-01T00:00:00Z' },
+    ])
+  })
+})

--- a/test/unit/hosted.test.ts
+++ b/test/unit/hosted.test.ts
@@ -118,6 +118,17 @@ describe('Hosted send provider', () => {
     ).rejects.toThrow('Resend: rate limit')
   })
 
+  test('throws when ok response is missing message id', async () => {
+    globalThis.fetch = mock(async () => {
+      return new Response(JSON.stringify({ sends_this_month: 1, monthly_limit: 100 }))
+    }) as typeof fetch
+
+    const provider = createHostedSendProvider('mk_key')
+    expect(
+      provider.send({ from: 'a@b.dev', to: ['c@d.com'], subject: 'NoId', text: 'x' })
+    ).rejects.toThrow('did not include a message id')
+  })
+
   test('uses default API URL when not specified', async () => {
     let requestUrl = ''
     globalThis.fetch = mock(async (url: string) => {


### PR DESCRIPTION
## Problem

`mails code --to <mailbox>` (without `--since`) defaulted `since` to `new Date().toISOString()` — the moment the command was run. All storage providers filter codes with `received_at > since`, so any verification code that arrived **before** the command started was never found. This broke the primary workflow: a code lands in the inbox, the user runs `mails code`, and the command times out instead of printing the code.

## Fix

- **`src/cli/commands/code.ts`**: stop defaulting `since` to the current time. When `--since` is omitted, no time filter is applied, and the storage providers (sqlite, db9, remote) already return the most recent existing code immediately — so a code that just landed is found on the first poll. An explicit `--since` still works exactly as before.
- **`src/providers/send/hosted.ts`** (secondary): the hosted send provider used `data.id!` on an optional response field. If the API returned an ok response without an `id`, `SendResult.id` silently became `undefined`, violating the `SendResult` contract. It now throws a clear error: `Send succeeded but the API response did not include a message id`.

## Tests

- New `CLI: code command` tests verify that `getCode` is called with `since: undefined` when `--since` is omitted (and that a pre-existing code is printed), and that an explicit `--since`/`--timeout` is passed through unchanged.
- New hosted provider test verifies the missing-id guard throws.
- Full suite: `bun run test` — 311 tests pass (298 + 13), 0 failures. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)